### PR TITLE
Add in fetch fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
+    "node-fetch": "^1.3.3",
     "qs": "^4.0.0"
   },
   "standard": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
 import { stringify } from 'qs'
+import node_fetch from 'node-fetch'
+
+if (typeof fetch !== 'function') {
+  let fetch = node_fetch;
+}
 
 const REDDIT_URL = 'https://www.reddit.com'
 const MATCH_REPLY_URLS = /(?:\[([^\]]+)\]\s*\()?(https?\:\/\/[^\)\s]+)\)?/gi


### PR DESCRIPTION
Adds in fetch fallback where fetch isn't natively available using node-fetch which provides a node HTTP style fetch() as opposed to an XMLHttpRequest hack. If fetch is natively available, then node-fetch will not be used. All tests passing.
